### PR TITLE
Feature/new address

### DIFF
--- a/voltixApp/VoltixApp.xcodeproj/project.pbxproj
+++ b/voltixApp/VoltixApp.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		049BBB662B71E987004C231F /* VaultItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 049BBB652B71E987004C231F /* VaultItem.swift */; };
 		049BBB682B71E9C5004C231F /* WifiBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 049BBB672B71E9C5004C231F /* WifiBar.swift */; };
 		4600167E2B71A12D00CE17C7 /* Tss.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4600167D2B71A12D00CE17C7 /* Tss.xcframework */; };
+		461BD0982B7F0AED00BFF703 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 461BD0972B7F0AED00BFF703 /* Extensions.swift */; };
 		465B09A42B7C01CC00952DD9 /* WalletUnspentOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 465B09A32B7C01CC00952DD9 /* WalletUnspentOutput.swift */; };
 		465B09A72B7C049400952DD9 /* UnspentOutputsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 465B09A62B7C049400952DD9 /* UnspentOutputsService.swift */; };
 		465B09A92B7C176700952DD9 /* TransactionDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 465B09A82B7C176700952DD9 /* TransactionDetailsViewModel.swift */; };
@@ -121,6 +122,7 @@
 		049BBB652B71E987004C231F /* VaultItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultItem.swift; sourceTree = "<group>"; };
 		049BBB672B71E9C5004C231F /* WifiBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WifiBar.swift; sourceTree = "<group>"; };
 		4600167D2B71A12D00CE17C7 /* Tss.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = Tss.xcframework; sourceTree = "<group>"; };
+		461BD0972B7F0AED00BFF703 /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		465B09A32B7C01CC00952DD9 /* WalletUnspentOutput.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WalletUnspentOutput.swift; sourceTree = "<group>"; };
 		465B09A62B7C049400952DD9 /* UnspentOutputsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnspentOutputsService.swift; sourceTree = "<group>"; };
 		465B09A82B7C176700952DD9 /* TransactionDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionDetailsViewModel.swift; sourceTree = "<group>"; };
@@ -382,6 +384,7 @@
 			isa = PBXGroup;
 			children = (
 				DE1572AB2B7174D3009BC7C5 /* Utils.swift */,
+				461BD0972B7F0AED00BFF703 /* Extensions.swift */,
 			);
 			path = util;
 			sourceTree = "<group>";
@@ -653,6 +656,7 @@
 				DE15729F2B70F284009BC7C5 /* KeysignDiscoveryView.swift in Sources */,
 				D9AD8EDC2B6723D10009F8D5 /* AppNavigationState.swift in Sources */,
 				465B09B12B7C85C000952DD9 /* ActivityViewModel.swift in Sources */,
+				461BD0982B7F0AED00BFF703 /* Extensions.swift in Sources */,
 				DE1572AC2B7174D3009BC7C5 /* Utils.swift in Sources */,
 				D9AD8EF32B67317C0009F8D5 /* SendPeerDiscoveryView.swift in Sources */,
 				465B09AF2B7C84C600952DD9 /* ShareSheet.swift in Sources */,

--- a/voltixApp/VoltixApp/Model/Vault.swift
+++ b/voltixApp/VoltixApp/Model/Vault.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import SwiftData
+import WalletCore
 
 @Model
 final class Vault : ObservableObject{
@@ -12,6 +13,25 @@ final class Vault : ObservableObject{
     var createdAt: Date = Date.now
     var pubKeyECDSA: String = ""
     var pubKeyEdDSA: String = ""
+    
+    private func createBitcoinAddress(from publicKeyString: String, prefix: UInt8 = 0x00) -> BitcoinAddress? {
+        guard let publicKeyData = Data(hexString: publicKeyString) else {
+            print("Invalid public key hex string")
+            return nil
+        }
+        // Assuming `PublicKey(data:type:)` initializer exists and works correctly
+        guard let publicKey = PublicKey(data: publicKeyData, type: .secp256k1) else { return nil }
+        
+        // Use your compatibleAddress function or any appropriate method to create a BitcoinAddress
+        // Assuming compatibleAddress is a static method on BitcoinAddress
+        return BitcoinAddress.compatibleAddress(publicKey: publicKey, prefix: prefix)
+    }
+    
+    var legacyBitcoinAddress: String {
+        let btc = createBitcoinAddress(from: pubKeyECDSA)
+        return btc?.description ?? "No BTC address available"
+    }
+    
     var keyshares = [KeyShare]()
     // it is important to record the localPartID of the vault, when the vault is created, the local party id has been record as part of it's local keyshare , and keygen committee
     // thus , when user change their device name , or if they lost the original device , and restore the keyshare to a new device , keysign can still work

--- a/voltixApp/VoltixApp/Model/WalletUnspentOutput.swift
+++ b/voltixApp/VoltixApp/Model/WalletUnspentOutput.swift
@@ -50,7 +50,7 @@ struct WalletUnspentOutput: Codable {
     let nTx: Int
     let unconfirmedNTx: Int
     let finalNTx: Int
-    let txrefs: [TransactionRef]
+    let txrefs: [TransactionRef]?
     let txUrl: String
     
     enum CodingKeys: String, CodingKey {
@@ -68,18 +68,17 @@ struct WalletUnspentOutput: Codable {
     }
 }
 
-// Structure for each transaction reference
 struct TransactionRef: Codable {
-    let txHash: String
-    let blockHeight: Int
-    let txInputN: Int
-    let txOutputN: Int
-    let value: Int
-    let refBalance: Int
-    let spent: Bool
-    let confirmations: Int
-    let confirmed: String
-    let doubleSpend: Bool
+    let txHash: String?
+    let blockHeight: Int?
+    let txInputN: Int?
+    let txOutputN: Int?
+    let value: Int?
+    let refBalance: Int?
+    let spent: Bool?
+    let confirmations: Int?
+    let confirmed: String?
+    let doubleSpend: Bool?
     
     enum CodingKeys: String, CodingKey {
         case txHash = "tx_hash"

--- a/voltixApp/VoltixApp/Views/Vault/VaultAssetsView.swift
+++ b/voltixApp/VoltixApp/Views/Vault/VaultAssetsView.swift
@@ -91,7 +91,7 @@ struct VaultAssetsView: View {
         .background(Color.white)
     }
     private func loadData() async {
-        await unspentOutputsViewModel.fetchUnspentOutputs(for: transactionDetailsViewModel.fromAddress)  // Make sure you define or have access to transactionDetailsViewModel
+        await unspentOutputsViewModel.fetchUnspentOutputs(for: appState.currentVault?.legacyBitcoinAddress ?? "")  // Make sure you define or have access to transactionDetailsViewModel
         await cryptoPriceViewModel.fetchCryptoPrices(for: "bitcoin", for: "usd")
     }
 }

--- a/voltixApp/VoltixApp/Views/Vault/VaultAssetsView.swift
+++ b/voltixApp/VoltixApp/Views/Vault/VaultAssetsView.swift
@@ -91,7 +91,10 @@ struct VaultAssetsView: View {
         .background(Color.white)
     }
     private func loadData() async {
-        await unspentOutputsViewModel.fetchUnspentOutputs(for: appState.currentVault?.legacyBitcoinAddress ?? "")  // Make sure you define or have access to transactionDetailsViewModel
-        await cryptoPriceViewModel.fetchCryptoPrices(for: "bitcoin", for: "usd")
+        transactionDetailsViewModel.fromAddress = appState.currentVault?.legacyBitcoinAddress ?? ""
+        if !transactionDetailsViewModel.fromAddress.isEmpty {
+            await unspentOutputsViewModel.fetchUnspentOutputs(for: transactionDetailsViewModel.fromAddress)
+            await cryptoPriceViewModel.fetchCryptoPrices(for: "bitcoin", for: "usd")
+        }
     }
 }

--- a/voltixApp/VoltixApp/Views/Vault/VaultSelectionView.swift
+++ b/voltixApp/VoltixApp/Views/Vault/VaultSelectionView.swift
@@ -28,6 +28,11 @@ struct VaultSelectionView: View {
                                 showingDeleteAlert = true
                             }
                         }
+                }.onAppear(){
+                    
+                    print("pubKeyECDSA: " + vault.pubKeyECDSA)
+                    print("Address: " + vault.legacyBitcoinAddress)
+                    
                 }
             }
         }

--- a/voltixApp/VoltixApp/Views/ViewModel/TransactionDetailsViewModel.swift
+++ b/voltixApp/VoltixApp/Views/ViewModel/TransactionDetailsViewModel.swift
@@ -25,7 +25,8 @@ class TransactionDetailsViewModel: ObservableObject, Hashable {
         hasher.combine(gas)
     }
     
-    @Published var fromAddress: String = "18cBEMRxXHqzWWCxZNtU91F5sbUNKhL5PX"
+    //18cBEMRxXHqzWWCxZNtU91F5sbUNKhL5PX
+    @Published var fromAddress: String = ""
     @Published var toAddress: String = ""
     @Published var amount: String = ""
     @Published var memo: String = ""

--- a/voltixApp/VoltixApp/util/Extensions.swift
+++ b/voltixApp/VoltixApp/util/Extensions.swift
@@ -1,0 +1,25 @@
+//
+//  Extensions.swift
+//  VoltixApp
+//
+//  Created by Enrique Souza Soares on 16/02/2024.
+//
+
+import Foundation
+extension Data {
+    init?(hexString: String) {
+        let len = hexString.count / 2
+        var data = Data(capacity: len)
+        for i in 0..<len {
+            let j = hexString.index(hexString.startIndex, offsetBy: i*2)
+            let k = hexString.index(j, offsetBy: 2)
+            let bytes = hexString[j..<k]
+            if var num = UInt8(bytes, radix: 16) {
+                data.append(&num, count: 1)
+            } else {
+                return nil
+            }
+        }
+        self = data
+    }
+}


### PR DESCRIPTION
Using wallet core we are now able to get the Bitcoin legacy address dynamically via pubKeyECDSA. 

I also adjusted the output transactions and unspent to support new addresses that have no transactions yet.