### PR TITLE
get and map all unspent transactions to be signed

### DIFF
--- a/voltixApp/VoltixApp/Model/BitcoinTransaction.swift
+++ b/voltixApp/VoltixApp/Model/BitcoinTransaction.swift
@@ -40,6 +40,29 @@ struct BitcoinTransaction: Codable {
         return formatter.string(from: NSNumber(value: balanceUSD))
     }
     
+    func selectUTXOsForPayment(amountNeeded: Int64) -> [TransactionRef] {
+
+        let txrefs = self.txrefs ?? []
+        
+        // Sort the UTXOs by their value in ascending order
+        let sortedTxrefs = txrefs.sorted { $0.value ?? 0 < $1.value  ?? 0 }
+        
+        var selectedTxrefs: [TransactionRef] = []
+        var total = 0
+        
+        // Iterate through the sorted UTXOs and select enough to cover the amountNeeded
+        for txref in sortedTxrefs {
+            selectedTxrefs.append(txref)
+            total += Int(txref.value  ?? 0)
+            if total >= amountNeeded {
+                break
+            }
+        }
+        
+        return selectedTxrefs
+    }
+    
+    
     
     let address: String
     let totalReceived: Int
@@ -79,7 +102,7 @@ struct TransactionRef: Codable, Identifiable {
     let blockHeight: Int?
     let txInputN: Int?
     let txOutputN: Int?
-    let value: Int?
+    let value: Int64?
     let refBalance: Int?
     let spent: Bool?
     let confirmations: Int?

--- a/voltixApp/VoltixApp/Model/SendTransaction.swift
+++ b/voltixApp/VoltixApp/Model/SendTransaction.swift
@@ -15,7 +15,7 @@ import WalletCore
 
 class SendTransaction: ObservableObject, Hashable {
     
-
+    
     init() {
         self.toAddress = ""
         self.amount = ""
@@ -68,12 +68,7 @@ class SendTransaction: ObservableObject, Hashable {
     }
     
     var feeInSats: Int64 {
-        
-        if gasDecimal == 0  {
-            return Int64(20) // 20 sats is the default
-        }
-        
-        return  Int64(gasDecimal * 100000000) // Normaly it comes int BTC
+        return  Int64(gas) ?? Int64(20) // Assuming that the gas is in sats
     }
     
     var amountDecimal: Double {
@@ -116,7 +111,7 @@ class SendTransaction: ObservableObject, Hashable {
         let amountStr = "\(amount)"
         let memoStr = "\(memo)"
         let gasStr = "\(gas)"
-
+        
         return "fromAddress: \(fromAddressStr), toAddress: \(toAddressStr), amount: \(amountStr), memo: \(memoStr), gas: \(gasStr)"
     }
     

--- a/voltixApp/VoltixApp/Services/BitcoinTransactionsService.swift
+++ b/voltixApp/VoltixApp/Services/BitcoinTransactionsService.swift
@@ -42,9 +42,5 @@ public class BitcoinTransactionsService: ObservableObject {
         } catch {
             print("error: ", error)
         }
-        catch {
-            errorMessage = "Fetch failed: \(error.localizedDescription)"
-            print("Fetch failed: \(error.localizedDescription)")
-        }
     }
 }

--- a/voltixApp/VoltixApp/Views/Send/SendInputDetailsView.swift
+++ b/voltixApp/VoltixApp/Views/Send/SendInputDetailsView.swift
@@ -100,8 +100,7 @@ struct SendInputDetailsView: View {
                             if let walletData = unspentOutputsService.walletData {
                                 self.sendTransactionModel.amount = walletData.balanceInBTC
                             } else {
-                                Text("Error to fetch the data")
-                                    .padding()
+                                Text("Error to fetch the data").padding()
                             }
                         }) {
                             Text("MAX")


### PR DESCRIPTION
I had to fetch and map the unspent transactions to be sent to be signed. 

We fetch them from the lowest to the highest to use small unspent transactions.