### PR TITLE
Construct unique device name for keygen and keysign

### DIFF
--- a/voltixApp/VoltixApp.xcodeproj/xcshareddata/xcschemes/VoltixApp.xcscheme
+++ b/voltixApp/VoltixApp.xcodeproj/xcshareddata/xcschemes/VoltixApp.xcscheme
@@ -17,7 +17,7 @@
                BlueprintIdentifier = "DE49A1622B65F6D9000F3AFB"
                BuildableName = "VoltixApp.app"
                BlueprintName = "VoltixApp"
-               ReferencedContainer = "container:VoltixApp.xcodeproj">
+               ReferencedContainer = "container:voltixApp.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
@@ -46,7 +46,7 @@
             BlueprintIdentifier = "DE49A1622B65F6D9000F3AFB"
             BuildableName = "VoltixApp.app"
             BlueprintName = "VoltixApp"
-            ReferencedContainer = "container:VoltixApp.xcodeproj">
+            ReferencedContainer = "container:voltixApp.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
       <EnvironmentVariables>
@@ -70,7 +70,7 @@
             BlueprintIdentifier = "DE49A1622B65F6D9000F3AFB"
             BuildableName = "VoltixApp.app"
             BlueprintName = "VoltixApp"
-            ReferencedContainer = "container:VoltixApp.xcodeproj">
+            ReferencedContainer = "container:voltixApp.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
    </ProfileAction>

--- a/voltixApp/VoltixApp/Utils/Utils.swift
+++ b/voltixApp/VoltixApp/Utils/Utils.swift
@@ -1,15 +1,15 @@
-    //
-    //  Utils.swift
-    //  VoltixApp
-    //
+//
+//  Utils.swift
+//  VoltixApp
+//
 
+import BigInt
+import CoreImage.CIFilterBuiltins
 import CryptoKit
 import Foundation
 import OSLog
-import UIKit
 import SwiftUI
-import CoreImage.CIFilterBuiltins
-import BigInt
+import UIKit
 
 enum Utils {
     static let logger = Logger(subsystem: "util", category: "network")
@@ -127,7 +127,7 @@ enum Utils {
         input.utf8.map { String(format: "%02x", $0) }.joined()
     }
     
-    public static func getQrImage(data:Any?,size: CGFloat) -> Image {
+    public static func getQrImage(data: Any?, size: CGFloat) -> Image {
         let context = CIContext()
         guard let qrFilter = CIFilter(name: "CIQRCodeGenerator") else {
             return Image(systemName: "xmark")
@@ -144,11 +144,14 @@ enum Utils {
         
         return Image(cgImage, scale: 1.0, orientation: .up, label: Text("QRCode"))
     }
+
     public static func isIOS() -> Bool {
         return true
     }
     
     public static func getLocalDeviceIdentity() -> String {
-        return UIDevice.current.name
+        let identifierForVendor = UIDevice.current.identifierForVendor?.uuidString
+        let parts = identifierForVendor?.components(separatedBy: "-")
+        return "\(UIDevice.current.name)-\(parts?.last ?? "N/A")"
     }
 }

--- a/voltixApp/VoltixApp/Views/Keygen/JoinKeygenView.swift
+++ b/voltixApp/VoltixApp/Views/Keygen/JoinKeygenView.swift
@@ -163,9 +163,6 @@ struct JoinKeygenView: View {
         .navigationTitle("JOIN KEYGEN")
         .navigationBarBackButtonHidden(true)
         .toolbar {
-            ToolbarItem(placement: .navigationBarLeading) {
-                NavigationButtons.backButton(presentationStack: $presentationStack)
-            }
             ToolbarItem(placement: .navigationBarTrailing) {
                 NavigationButtons.questionMarkButton
             }
@@ -180,6 +177,8 @@ struct JoinKeygenView: View {
                 self.localPartyID = Utils.getLocalDeviceIdentity()
                 appState.creatingVault?.localPartyID = self.localPartyID
             }
+        }.onDisappear {
+            self.currentStatus = .FailToStart
         }
     }
     

--- a/voltixApp/VoltixApp/Views/Keygen/JoinKeygenView.swift
+++ b/voltixApp/VoltixApp/Views/Keygen/JoinKeygenView.swift
@@ -59,6 +59,7 @@ struct JoinKeygenView: View {
                         
                     case .DiscoverService:
                         HStack {
+                            Text("thisDevice" + ":" + self.localPartyID)
                             Text("Discovering mediator service, please wait...".uppercased())
                                 .font(.custom("Menlo", size: 15).bold())
                                 .multilineTextAlignment(.center)
@@ -82,6 +83,7 @@ struct JoinKeygenView: View {
                     case .JoinKeygen:
                         
                         HStack {
+                            Text("thisDevice" + ":" + self.localPartyID)
                             Text("Joining key generation process, please wait...".uppercased())
                                 .font(.custom("Menlo", size: 15).bold())
                                 .multilineTextAlignment(.center)
@@ -93,6 +95,7 @@ struct JoinKeygenView: View {
                         
                     case .WaitingForKeygenToStart:
                         HStack {
+                            Text("thisDevice" + ":" + self.localPartyID)
                             Text("Waiting for key generation to start, please be patient...".uppercased())
                                 .font(.custom("Menlo", size: 15).bold())
                                 .multilineTextAlignment(.center)
@@ -103,7 +106,7 @@ struct JoinKeygenView: View {
                             Task {
                                 repeat {
                                     checkKeygenStarted()
-                                    try await Task.sleep(nanoseconds: 1_000_000_000)
+                                    try await Task.sleep(for: .seconds(1))
                                 } while self.currentStatus == .WaitingForKeygenToStart
                             }
                         }

--- a/voltixApp/VoltixApp/Views/Keygen/JoinKeygenView.swift
+++ b/voltixApp/VoltixApp/Views/Keygen/JoinKeygenView.swift
@@ -63,7 +63,7 @@ struct JoinKeygenView: View {
                                 Text("thisDevice")
                                     .font(.custom("Menlo", size: 15).bold())
                                     .multilineTextAlignment(.center)
-                                Text(":" + self.localPartyID)
+                                Text(self.localPartyID)
                                     .font(.custom("Menlo", size: 15).bold())
                                     .multilineTextAlignment(.center)
                             }
@@ -93,7 +93,7 @@ struct JoinKeygenView: View {
                         VStack {
                             HStack {
                                 Text("thisDevice")
-                                Text(":" + self.localPartyID)
+                                Text(self.localPartyID)
                             }
                             HStack {
                                 Text("Joining key generation process, please wait...".uppercased())
@@ -110,7 +110,7 @@ struct JoinKeygenView: View {
                         VStack {
                             HStack {
                                 Text("thisDevice")
-                                Text(":" + self.localPartyID)
+                                Text(self.localPartyID)
                             }
                             HStack {
                                 Text("Waiting for key generation to start, please be patient...".uppercased())

--- a/voltixApp/VoltixApp/Views/Keygen/JoinKeygenView.swift
+++ b/voltixApp/VoltixApp/Views/Keygen/JoinKeygenView.swift
@@ -58,20 +58,28 @@ struct JoinKeygenView: View {
                         .buttonStyle(PlainButtonStyle())
                         
                     case .DiscoverService:
-                        HStack {
-                            Text("thisDevice" + ":" + self.localPartyID)
-                            Text("Discovering mediator service, please wait...".uppercased())
-                                .font(.custom("Menlo", size: 15).bold())
-                                .multilineTextAlignment(.center)
+                        VStack {
+                            HStack {
+                                Text("thisDevice")
+                                    .font(.custom("Menlo", size: 15).bold())
+                                    .multilineTextAlignment(.center)
+                                Text(":" + self.localPartyID)
+                                    .font(.custom("Menlo", size: 15).bold())
+                                    .multilineTextAlignment(.center)
+                            }
+                            HStack {
+                                Text("Discovering mediator service, please wait...".uppercased())
+                                    .font(.custom("Menlo", size: 15).bold())
+                                    .multilineTextAlignment(.center)
                             
-                            if serviceDelegate.serverURL == nil {
-                                ProgressView().progressViewStyle(.circular).padding(2)
-                            } else {
-                                Image(systemName: "checkmark").onAppear {
-                                    currentStatus = .JoinKeygen
+                                if serviceDelegate.serverURL == nil {
+                                    ProgressView().progressViewStyle(.circular).padding(2)
+                                } else {
+                                    Image(systemName: "checkmark").onAppear {
+                                        currentStatus = .JoinKeygen
+                                    }
                                 }
                             }
-                            
                         }.padding(.vertical, 30)
                             .onAppear {
                                 logger.info("Start to discover service")
@@ -82,24 +90,34 @@ struct JoinKeygenView: View {
                         
                     case .JoinKeygen:
                         
-                        HStack {
-                            Text("thisDevice" + ":" + self.localPartyID)
-                            Text("Joining key generation process, please wait...".uppercased())
-                                .font(.custom("Menlo", size: 15).bold())
-                                .multilineTextAlignment(.center)
-                                .onAppear {
-                                    joinKeygenCommittee()
-                                    currentStatus = .WaitingForKeygenToStart
-                                }
+                        VStack {
+                            HStack {
+                                Text("thisDevice")
+                                Text(":" + self.localPartyID)
+                            }
+                            HStack {
+                                Text("Joining key generation process, please wait...".uppercased())
+                                    .font(.custom("Menlo", size: 15).bold())
+                                    .multilineTextAlignment(.center)
+                                    .onAppear {
+                                        joinKeygenCommittee()
+                                        currentStatus = .WaitingForKeygenToStart
+                                    }
+                            }
                         }.padding(.vertical, 30)
                         
                     case .WaitingForKeygenToStart:
-                        HStack {
-                            Text("thisDevice" + ":" + self.localPartyID)
-                            Text("Waiting for key generation to start, please be patient...".uppercased())
-                                .font(.custom("Menlo", size: 15).bold())
-                                .multilineTextAlignment(.center)
-                            ProgressView().progressViewStyle(.circular).padding(2)
+                        VStack {
+                            HStack {
+                                Text("thisDevice")
+                                Text(":" + self.localPartyID)
+                            }
+                            HStack {
+                                Text("Waiting for key generation to start, please be patient...".uppercased())
+                                    .font(.custom("Menlo", size: 15).bold())
+                                    .multilineTextAlignment(.center)
+                                ProgressView().progressViewStyle(.circular).padding(2)
+                            }
                         }
                         .padding(.vertical, 30)
                         .task {

--- a/voltixApp/VoltixApp/Views/Keysign/JoinKeysignView.swift
+++ b/voltixApp/VoltixApp/Views/Keysign/JoinKeysignView.swift
@@ -49,6 +49,7 @@ struct JoinKeysignView: View {
                         })
                     case .DiscoverService:
                         HStack {
+                            Text("thisDevice" + ":" + self.localPartyID)
                             Text("Looking for the mediator service...")
                                 .font(Font.custom("Menlo", size: 15)
                                     .weight(.bold))
@@ -113,6 +114,7 @@ struct JoinKeysignView: View {
                         }
                     case .WaitingForKeysignToStart:
                         HStack {
+                            Text("thisDevice" + ":" + self.localPartyID)
                             Text("Waiting for the signing process to begin...")
                                 .font(Font.custom("Menlo", size: 15)
                                     .weight(.bold))

--- a/voltixApp/VoltixApp/Views/Keysign/JoinKeysignView.swift
+++ b/voltixApp/VoltixApp/Views/Keysign/JoinKeysignView.swift
@@ -202,6 +202,9 @@ struct JoinKeysignView: View {
                 self.localPartyID = Utils.getLocalDeviceIdentity()
             }
         }
+        .onDisappear {
+            self.currentStatus = .FailedToStart
+        }
     }
     
     private func checkKeysignStarted() {

--- a/voltixApp/VoltixApp/Views/Keysign/JoinKeysignView.swift
+++ b/voltixApp/VoltixApp/Views/Keysign/JoinKeysignView.swift
@@ -48,26 +48,31 @@ struct JoinKeysignView: View {
                             CodeScannerView(codeTypes: [.qr], completion: self.handleScan)
                         })
                     case .DiscoverService:
-                        HStack {
-                            Text("thisDevice" + ":" + self.localPartyID)
-                            Text("Looking for the mediator service...")
-                                .font(Font.custom("Menlo", size: 15)
-                                    .weight(.bold))
-                                .multilineTextAlignment(.center)
-                            if self.serviceDelegate.serverURL == nil {
-                                ProgressView()
-                                    .progressViewStyle(.circular)
-                                    .padding(2)
-                            } else {
-                                Image(systemName: "checkmark").onAppear {
-                                    self.currentStatus = .JoinKeysign
+                        VStack {
+                            HStack {
+                                Text("thisDevice")
+                                Text(":" + self.localPartyID)
+                            }
+                            HStack {
+                                Text("Looking for the mediator service...")
+                                    .font(Font.custom("Menlo", size: 15)
+                                        .weight(.bold))
+                                    .multilineTextAlignment(.center)
+                                if self.serviceDelegate.serverURL == nil {
+                                    ProgressView()
+                                        .progressViewStyle(.circular)
+                                        .padding(2)
+                                } else {
+                                    Image(systemName: "checkmark").onAppear {
+                                        self.currentStatus = .JoinKeysign
+                                    }
                                 }
                             }
                         }.onAppear {
                             logger.info("Start to discover service")
                             self.netService = NetService(domain: "local.", type: "_http._tcp.", name: self.serviceName)
-                            netService.delegate = self.serviceDelegate
-                            netService.resolve(withTimeout: TimeInterval(10))
+                            self.netService.delegate = self.serviceDelegate
+                            self.netService.resolve(withTimeout: TimeInterval(10))
                         }
                     case .JoinKeysign:
                         VStack(alignment: .leading) {
@@ -113,20 +118,25 @@ struct JoinKeysignView: View {
                             .padding(.vertical, 15)
                         }
                     case .WaitingForKeysignToStart:
-                        HStack {
-                            Text("thisDevice" + ":" + self.localPartyID)
-                            Text("Waiting for the signing process to begin...")
-                                .font(Font.custom("Menlo", size: 15)
-                                    .weight(.bold))
-                                .multilineTextAlignment(.center)
-                            ProgressView()
-                                .progressViewStyle(.circular)
-                                .padding(2)
+                        VStack {
+                            HStack {
+                                Text("thisDevice")
+                                Text(":" + self.localPartyID)
+                            }
+                            HStack {
+                                Text("Waiting for the signing process to begin...")
+                                    .font(Font.custom("Menlo", size: 15)
+                                        .weight(.bold))
+                                    .multilineTextAlignment(.center)
+                                ProgressView()
+                                    .progressViewStyle(.circular)
+                                    .padding(2)
+                            }
                         }.task {
                             Task {
                                 repeat {
                                     self.checkKeysignStarted()
-                                    try await Task.sleep(nanoseconds: 1_000_000_000)
+                                    try await Task.sleep(for: .seconds(1))
                                 } while self.currentStatus == .WaitingForKeysignToStart
                             }
                         }

--- a/voltixApp/VoltixApp/Views/Keysign/JoinKeysignView.swift
+++ b/voltixApp/VoltixApp/Views/Keysign/JoinKeysignView.swift
@@ -51,7 +51,13 @@ struct JoinKeysignView: View {
                         VStack {
                             HStack {
                                 Text("thisDevice")
-                                Text(":" + self.localPartyID)
+                                    .font(Font.custom("Menlo", size: 15)
+                                        .weight(.bold))
+                                    .multilineTextAlignment(.center)
+                                Text(self.localPartyID)
+                                    .font(Font.custom("Menlo", size: 15)
+                                        .weight(.bold))
+                                    .multilineTextAlignment(.center)
                             }
                             HStack {
                                 Text("Looking for the mediator service...")
@@ -121,7 +127,13 @@ struct JoinKeysignView: View {
                         VStack {
                             HStack {
                                 Text("thisDevice")
-                                Text(":" + self.localPartyID)
+                                    .font(Font.custom("Menlo", size: 15)
+                                        .weight(.bold))
+                                    .multilineTextAlignment(.center)
+                                Text(self.localPartyID)
+                                    .font(Font.custom("Menlo", size: 15)
+                                        .weight(.bold))
+                                    .multilineTextAlignment(.center)
                             }
                             HStack {
                                 Text("Waiting for the signing process to begin...")
@@ -172,11 +184,8 @@ struct JoinKeysignView: View {
             .padding()
         }
         .navigationTitle("Join Key Signing")
-        .navigationBarBackButtonHidden(true)
+        .navigationBarBackButtonHidden(false)
         .toolbar {
-            ToolbarItem(placement: .navigationBarLeading) {
-                NavigationButtons.backButton(presentationStack: self.$presentationStack)
-            }
             ToolbarItem(placement: .navigationBarTrailing) {
                 NavigationButtons.questionMarkButton
             }

--- a/voltixApp/VoltixApp/Views/Vault/ListVaultAssetView.swift
+++ b/voltixApp/VoltixApp/Views/Vault/ListVaultAssetView.swift
@@ -61,19 +61,19 @@ struct ListVaultAssetView: View {
                     showingCoinList = true
                 }.buttonStyle(PlainButtonStyle())
                 
-                Button("test", systemImage: "doc.questionmark") {
-                    guard let vault = appState.currentVault else { return }
-                    let coin = vault.coins.first { $0.ticker == "SOL" }
-                    if let coin {
-                        self.presentationStack.append(.KeysignDiscovery(KeysignPayload(
-                            coin: coin,
-                            toAddress: "HWC9MFd7nYy421xMYx4mwMxw3HNC6hcwiUMnPTEQc4zG",
-                            toAmount: 100_000_0, // 0.01 RUNE
-                            chainSpecific: BlockChainSpecific.Solana(recentBlockHash: "D9xgxNtjPfZMNDnQbywr4h3XNy67pN8KNJfKmHPwoqu9"),
-                            utxos: [],
-                            memo: "voltix")))
-                    }
-                }.buttonStyle(PlainButtonStyle())
+//                Button("test", systemImage: "doc.questionmark") {
+//                    guard let vault = appState.currentVault else { return }
+//                    let coin = vault.coins.first { $0.ticker == "SOL" }
+//                    if let coin {
+//                        self.presentationStack.append(.KeysignDiscovery(KeysignPayload(
+//                            coin: coin,
+//                            toAddress: "HWC9MFd7nYy421xMYx4mwMxw3HNC6hcwiUMnPTEQc4zG",
+//                            toAmount: 100_000_0, // 0.01 RUNE
+//                            chainSpecific: BlockChainSpecific.Solana(recentBlockHash: "D9xgxNtjPfZMNDnQbywr4h3XNy67pN8KNJfKmHPwoqu9"),
+//                            utxos: [],
+//                            memo: "voltix")))
+//                    }
+//                }.buttonStyle(PlainButtonStyle())
             }
         }
         .onAppear {

--- a/voltixApp/VoltixApp/Views/Vault/ListVaultAssetView.swift
+++ b/voltixApp/VoltixApp/Views/Vault/ListVaultAssetView.swift
@@ -61,19 +61,19 @@ struct ListVaultAssetView: View {
                     showingCoinList = true
                 }.buttonStyle(PlainButtonStyle())
                 
-//                Button("test", systemImage: "doc.questionmark") {
-//                    guard let vault = appState.currentVault else { return }
-//                    let coin = vault.coins.first { $0.ticker == "SOL" }
-//                    if let coin {
-//                        self.presentationStack.append(.KeysignDiscovery(KeysignPayload(
-//                            coin: coin,
-//                            toAddress: "HWC9MFd7nYy421xMYx4mwMxw3HNC6hcwiUMnPTEQc4zG",
-//                            toAmount: 100_000_0, // 0.01 RUNE
-//                            chainSpecific: BlockChainSpecific.Solana(recentBlockHash: "D9xgxNtjPfZMNDnQbywr4h3XNy67pN8KNJfKmHPwoqu9"),
-//                            utxos: [],
-//                            memo: "voltix")))
-//                    }
-//                }.buttonStyle(PlainButtonStyle())
+                Button("test", systemImage: "doc.questionmark") {
+                    guard let vault = appState.currentVault else { return }
+                    let coin = vault.coins.first { $0.ticker == "SOL" }
+                    if let coin {
+                        self.presentationStack.append(.KeysignDiscovery(KeysignPayload(
+                            coin: coin,
+                            toAddress: "HWC9MFd7nYy421xMYx4mwMxw3HNC6hcwiUMnPTEQc4zG",
+                            toAmount: 100_000_0, // 0.01 RUNE
+                            chainSpecific: BlockChainSpecific.Solana(recentBlockHash: "D9xgxNtjPfZMNDnQbywr4h3XNy67pN8KNJfKmHPwoqu9"),
+                            utxos: [],
+                            memo: "voltix")))
+                    }
+                }.buttonStyle(PlainButtonStyle())
             }
         }
         .onAppear {

--- a/voltixApp/VoltixApp/en.lproj/Localizable.strings
+++ b/voltixApp/VoltixApp/en.lproj/Localizable.strings
@@ -6,3 +6,4 @@
   
 */
 "secureCryptoVault" = "SECURE CRYPTO VAULT";
+"thisDevice" = "THIS DEVICE:";


### PR DESCRIPTION
Currently we are using `UIDevice.current.name` as local party's identifier when keygen and keysign , but since IOS15 , `UIDevice.current.name` will only return a generic name , like `iphone` or `ipad` , instead the name user put in their settings

If we get the device name in user's settings , then we have to request a special entitlement. 

I don't want to request the entitlement , just I updated the view and also the way how we get the local party identifier

Also , currently for the back button on the top navigation bar , we are using 
```
ToolbarItem(placement: .navigationBarLeading) {
                NavigationButtons.backButton(presentationStack: self.$presentationStack)
            }
```
I removed this , just let it to use the standard one , it says `back` , but it is ok