### PR TITLE
PeerDiscoveryView Continue button padding

### DIFF
--- a/voltixApp/VoltixApp/Views/Keygen/PeerDiscoveryView.swift
+++ b/voltixApp/VoltixApp/Views/Keygen/PeerDiscoveryView.swift
@@ -170,10 +170,10 @@ struct PeerDiscoveryView: View {
             self.participantDiscovery.stop()
         }) {
             FilledButton(title: "continue")
-                .disabled(self.selections.count < 2)
-            
-        }.disabled(self.selections.count < 2)
-            .grayscale(self.selections.count < 2 ? 0 : 1)
+                .padding(40)
+        }
+        .disabled(self.selections.count < 2)
+        .opacity(self.selections.count < 2 ? 0.8 : 1)
     }
     
     private func getQrImage(size: CGFloat) -> Image {


### PR DESCRIPTION
**Description**
- wrong paddings
- `grayscale` does not change button appearance

**Before**
<img width="431" alt="Screenshot 2024-03-17 at 11 54 06" src="https://github.com/voltix-vault/voltix/assets/5384197/8bca2361-daa7-40f9-a489-74d6e1379a1f">

**After**
<img width="417" alt="Screenshot 2024-03-17 at 12 28 05" src="https://github.com/voltix-vault/voltix/assets/5384197/39bc61f2-0659-4937-9ac6-aaebdfbad21f">
