### PR TITLE
Hide main device when keygen/keysign

### DIFF
--- a/voltixApp/VoltixApp/Services/Ethereum/EtherscanService.swift
+++ b/voltixApp/VoltixApp/Services/Ethereum/EtherscanService.swift
@@ -3,5 +3,5 @@ import BigInt
 
 class EthService: RpcEvmService {
     static let ethRpcEndpoint = Endpoint.ethServiceRpcService
-    static let shared = BSCService(ethRpcEndpoint)
+    static let shared = EthService(ethRpcEndpoint)
 }

--- a/voltixApp/VoltixApp/View Models/KeygenPeerDiscoveryViewModel.swift
+++ b/voltixApp/VoltixApp/View Models/KeygenPeerDiscoveryViewModel.swift
@@ -73,7 +73,7 @@ class KeygenPeerDiscoveryViewModel: ObservableObject {
         self.mediator.start(name: self.serviceName)
         self.logger.info("mediator server started")
         self.startSession()
-        self.participantDiscovery?.getParticipants(serverAddr: self.serverAddr, sessionID: self.sessionID)
+        self.participantDiscovery?.getParticipants(serverAddr: self.serverAddr, sessionID: self.sessionID,localParty: self.localPartyID)
     }
     
     func startKeygen() {

--- a/voltixApp/VoltixApp/View Models/KeysignDiscoveryViewModel.swift
+++ b/voltixApp/VoltixApp/View Models/KeysignDiscoveryViewModel.swift
@@ -17,9 +17,9 @@ class KeysignDiscoveryViewModel: ObservableObject {
     var vault: Vault
     var keysignPayload: KeysignPayload
     var participantDiscovery: ParticipantDiscovery?
-
+    
     private let mediator = Mediator.shared
-
+    
     let serverAddr = "http://127.0.0.1:8080"
     @Published var selections = Set<String>()
     @Published var sessionID = ""
@@ -28,13 +28,13 @@ class KeysignDiscoveryViewModel: ObservableObject {
     @Published var keysignMessages = [String]()
     @Published var serviceName = ""
     @Published var errorMessage = ""
-
+    
     init() {
         self.vault = Vault(name: "New Vault")
         self.keysignPayload = KeysignPayload(coin: Coin.example, toAddress: "", toAmount: 0, chainSpecific: BlockChainSpecific.UTXO(byteFee: 0), utxos: [], memo: nil, swapPayload: nil)
         self.participantDiscovery = nil
     }
-
+    
     func setData(vault: Vault, keysignPayload: KeysignPayload, participantDiscovery: ParticipantDiscovery) {
         self.vault = vault
         self.keysignPayload = keysignPayload
@@ -64,12 +64,12 @@ class KeysignDiscoveryViewModel: ObservableObject {
             self.status = .FailToStart
         }
     }
-
+    
     func startDiscovery() {
         self.mediator.start(name: self.serviceName)
         self.logger.info("mediator server started")
         self.startKeysignSession()
-        self.participantDiscovery?.getParticipants(serverAddr: self.serverAddr, sessionID: self.sessionID)
+        self.participantDiscovery?.getParticipants(serverAddr: self.serverAddr, sessionID: self.sessionID,localParty: self.localPartyID)
     }
     
     @MainActor func startKeysign(vault: Vault, viewModel: SendCryptoViewModel) -> KeysignView {
@@ -98,7 +98,7 @@ class KeysignDiscoveryViewModel: ObservableObject {
     func stopDiscovery() {
         self.participantDiscovery?.stop()
     }
-
+    
     private func startKeysignSession() {
         let urlString = "\(self.serverAddr)/\(self.sessionID)"
         let body = [self.localPartyID]

--- a/voltixApp/VoltixApp/Views/Keygen/PeerDiscoveryView.swift
+++ b/voltixApp/VoltixApp/Views/Keygen/PeerDiscoveryView.swift
@@ -212,7 +212,7 @@ struct PeerDiscoveryView: View {
             viewModel.selections.insert(peer)
         }
         let totalSigners = viewModel.selections.count
-        if totalSigners >= 3 {
+        if totalSigners >= 2 {
             let threshold = Int(ceil(Double(totalSigners) * 2.0 / 3.0))
             viewModel.vaultDetail = "\(threshold)of\(totalSigners) Vault"
         }

--- a/voltixApp/VoltixApp/Views/Keygen/PeerDiscoveryView.swift
+++ b/voltixApp/VoltixApp/Views/Keygen/PeerDiscoveryView.swift
@@ -95,9 +95,9 @@ struct PeerDiscoveryView: View {
     
     var portraitContent: some View {
         VStack {
+            vaultDetail
             paringBarcode
             list
-            vaultDetail
         }
     }
     

--- a/voltixApp/VoltixApp/Views/Keysign/JoinKeysignDoneView.swift
+++ b/voltixApp/VoltixApp/Views/Keysign/JoinKeysignDoneView.swift
@@ -98,7 +98,7 @@ struct JoinKeysignDoneView: View {
     
     var continueButton: some View {
         NavigationLink {
-            HomeView()
+            HomeView(selectedVault: viewModel.vault,showVaultsList: false)
         } label: {
             FilledButton(title: "DONE")
                 .padding(20)

--- a/voltixApp/VoltixApp/Views/Keysign/KeysignView.swift
+++ b/voltixApp/VoltixApp/Views/Keysign/KeysignView.swift
@@ -16,22 +16,22 @@ struct KeysignView: View {
     let sendCryptoViewModel: SendCryptoViewModel?
     
     let logger = Logger(subsystem: "keysign", category: "tss")
-
+    
     @StateObject var viewModel = KeysignViewModel()
-
+    
     var body: some View {
         ZStack {
             switch viewModel.status {
-                case .CreatingInstance:
-                    SendCryptoKeysignView(title: "creatingTssInstance")
-                case .KeysignECDSA:
-                    SendCryptoKeysignView(title: "signingWithECDSA")
-                case .KeysignEdDSA:
-                    SendCryptoKeysignView(title: "signingWithEdDSA")
-                case .KeysignFinished:
-                    keysignFinished
-                case .KeysignFailed:
-                    SendCryptoKeysignView(title: "Sorry keysign failed, you can retry it,error: \(viewModel.keysignError)", showError: true)
+            case .CreatingInstance:
+                SendCryptoKeysignView(vault:vault,title: "creatingTssInstance")
+            case .KeysignECDSA:
+                SendCryptoKeysignView(vault:vault,title: "signingWithECDSA")
+            case .KeysignEdDSA:
+                SendCryptoKeysignView(vault:vault,title: "signingWithEdDSA")
+            case .KeysignFinished:
+                keysignFinished
+            case .KeysignFailed:
+                SendCryptoKeysignView(vault:vault,title: "Sorry keysign failed, you can retry it,error: \(viewModel.keysignError)", showError: true)
             }
         }
         .onAppear {
@@ -96,7 +96,7 @@ struct KeysignView: View {
         sessionID: "session",
         keysignType: .ECDSA,
         messsageToSign: ["message"],
-        keysignPayload: nil, 
+        keysignPayload: nil,
         sendCryptoViewModel: nil
     )
 }

--- a/voltixApp/VoltixApp/Views/Keysign/ParticipantDiscovery.swift
+++ b/voltixApp/VoltixApp/Views/Keysign/ParticipantDiscovery.swift
@@ -17,7 +17,7 @@ class ParticipantDiscovery: ObservableObject {
         self.discoverying = false
     }
     
-    func getParticipants(serverAddr: String, sessionID: String) {
+    func getParticipants(serverAddr: String, sessionID: String, localParty: String) {
         let urlString = "\(serverAddr)/\(sessionID)"
         Task.detached {
             repeat {
@@ -33,6 +33,9 @@ class ParticipantDiscovery: ObservableObject {
                             let peers = try decoder.decode([String].self, from: data)
                             DispatchQueue.main.async {
                                 for peer in peers {
+                                    if peer == localParty {
+                                        continue
+                                    }
                                     if !self.peersFound.contains(peer) {
                                         self.peersFound.append(peer)
                                     }

--- a/voltixApp/VoltixApp/Views/Send/SendCryptoDoneView.swift
+++ b/voltixApp/VoltixApp/Views/Send/SendCryptoDoneView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct SendCryptoDoneView: View {
+    let vault: Vault
     let hash: String
     let explorerLink: String
     @Environment(\.openURL) var openURL
@@ -90,7 +91,7 @@ struct SendCryptoDoneView: View {
     
     var continueButton: some View {
         NavigationLink {
-            HomeView()
+            HomeView(selectedVault: vault,showVaultsList: false)
         } label: {
             FilledButton(title: "complete")
         }
@@ -111,6 +112,6 @@ struct SendCryptoDoneView: View {
 }
 
 #Preview {
-    SendCryptoDoneView(hash: "bc1psrjtwm7682v6nhx2uwfgcfelrennd7pcvqq7v6w", explorerLink: "https://blockstream.info/tx/")
+    SendCryptoDoneView(vault:Vault.example,hash: "bc1psrjtwm7682v6nhx2uwfgcfelrennd7pcvqq7v6w", explorerLink: "https://blockstream.info/tx/")
         .previewDevice("iPhone 13 Pro")
 }

--- a/voltixApp/VoltixApp/Views/Send/SendCryptoKeysignView.swift
+++ b/voltixApp/VoltixApp/Views/Send/SendCryptoKeysignView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct SendCryptoKeysignView: View {
+    let vault: Vault
     let title: String
     var showError = false
     @State var didSwitch = false
@@ -94,7 +95,7 @@ struct SendCryptoKeysignView: View {
     
     var tryAgainButton: some View {
         NavigationLink {
-            HomeView()
+            HomeView(selectedVault: vault,showVaultsList: false)
         } label: {
             FilledButton(title: "tryAgain")
         }
@@ -107,6 +108,6 @@ struct SendCryptoKeysignView: View {
         Color.blue800
             .ignoresSafeArea()
         
-        SendCryptoKeysignView(title: "signing")
+        SendCryptoKeysignView(vault:Vault.example,title: "signing")
     }
 }

--- a/voltixApp/VoltixApp/Views/Send/SendCryptoView.swift
+++ b/voltixApp/VoltixApp/Views/Send/SendCryptoView.swift
@@ -16,7 +16,7 @@ struct SendCryptoView: View {
     @StateObject var sendCryptoViewModel = SendCryptoViewModel()
     @StateObject var sendCryptoVerifyViewModel = SendCryptoVerifyViewModel()
     
-	
+    
     @State var keysignPayload: KeysignPayload? = nil
     @State var keysignView: KeysignView? = nil
     
@@ -126,7 +126,7 @@ struct SendCryptoView: View {
     var doneView: some View {
         ZStack {
             if let hash = sendCryptoViewModel.hash {
-                SendCryptoDoneView(hash: hash,explorerLink: Endpoint.getExplorerURL(chainTicker: keysignPayload?.coin.chain.ticker ?? "", txid: hash))
+                SendCryptoDoneView(vault:vault,hash: hash,explorerLink: Endpoint.getExplorerURL(chainTicker: keysignPayload?.coin.chain.ticker ?? "", txid: hash))
             } else {
                 SendCryptoSigningErrorView()
             }


### PR DESCRIPTION
1. Hide main device when keygen/keysign , and add it to selection list by default
2. When keysign finished / failed retry , go back to vault detail view
3. Show 2/3 vault , 3/4 vault on keygen