### PR TITLE
Fix Broadcast tx , one device report success and another one report error

### DIFF
--- a/voltixApp/VoltixApp.xcodeproj/project.pbxproj
+++ b/voltixApp/VoltixApp.xcodeproj/project.pbxproj
@@ -253,6 +253,7 @@
 		DEFF58FA2BCF85FA005DFDF9 /* maya.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFF58F92BCF85FA005DFDF9 /* maya.swift */; };
 		DEFF58FC2BCFB384005DFDF9 /* MayaChainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFF58FB2BCFB384005DFDF9 /* MayaChainService.swift */; };
 		DEFF58FE2BD13E5D005DFDF9 /* ThreadSafeDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFF58FD2BD13E5D005DFDF9 /* ThreadSafeDictionary.swift */; };
+		DEFF59012BD238CF005DFDF9 /* SignedTransactionResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFF59002BD238CF005DFDF9 /* SignedTransactionResult.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -527,6 +528,7 @@
 		DEFF58F92BCF85FA005DFDF9 /* maya.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = maya.swift; sourceTree = "<group>"; };
 		DEFF58FB2BCFB384005DFDF9 /* MayaChainService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MayaChainService.swift; sourceTree = "<group>"; };
 		DEFF58FD2BD13E5D005DFDF9 /* ThreadSafeDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadSafeDictionary.swift; sourceTree = "<group>"; };
+		DEFF59002BD238CF005DFDF9 /* SignedTransactionResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignedTransactionResult.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1137,6 +1139,7 @@
 				DE63AE522BBA627B001BBE5C /* atom.swift */,
 				46DE088B2BD087D800AE8BDE /* kujira.swift */,
 				DEFF58F92BCF85FA005DFDF9 /* maya.swift */,
+				DEFF59002BD238CF005DFDF9 /* SignedTransactionResult.swift */,
 			);
 			path = Chains;
 			sourceTree = "<group>";
@@ -1378,6 +1381,7 @@
 				DE49A1B32B6A1088000F3AFB /* XCRemoteSwiftPackageReference "CodeScanner" */,
 				DE28F52F2B7B0F6A00E33058 /* XCLocalSwiftPackageReference "../WalletCore" */,
 				DEEDAEE62B8B50A4005170E8 /* XCRemoteSwiftPackageReference "BigInt" */,
+				DEFF59022BD23A12005DFDF9 /* XCRemoteSwiftPackageReference "CryptoSwift" */,
 			);
 			productRefGroup = DE49A1642B65F6D9000F3AFB /* Products */;
 			projectDirPath = "";
@@ -1512,6 +1516,7 @@
 				A61173592BC8A10D00D616F9 /* ChainCellViewModel.swift in Sources */,
 				DE6DCB952B97D88A009A39D5 /* THORChainSwapPayload.swift in Sources */,
 				A6966D2B2BA4018600903CA4 /* SendCryptoAmountTextField.swift in Sources */,
+				DEFF59012BD238CF005DFDF9 /* SignedTransactionResult.swift in Sources */,
 				46AC40A82B920061001704E6 /* EtherscanService.swift in Sources */,
 				A62758F22B97B10600ADE3A6 /* Endpoint.swift in Sources */,
 				465A8D532B9E689B006E7457 /* SolanaService.swift in Sources */,
@@ -2087,6 +2092,14 @@
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 5.1.0;
+			};
+		};
+		DEFF59022BD23A12005DFDF9 /* XCRemoteSwiftPackageReference "CryptoSwift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/krzyzanowskim/CryptoSwift.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.8.2;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/voltixApp/VoltixApp.xcodeproj/project.pbxproj
+++ b/voltixApp/VoltixApp.xcodeproj/project.pbxproj
@@ -188,6 +188,7 @@
 		DE1572AC2B7174D3009BC7C5 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE1572AB2B7174D3009BC7C5 /* Utils.swift */; };
 		DE28F5312B7B0FE900E33058 /* WalletCore in Frameworks */ = {isa = PBXBuildFile; productRef = DE28F5302B7B0FE900E33058 /* WalletCore */; };
 		DE28F5332B7B0FED00E33058 /* SwiftProtobuf in Frameworks */ = {isa = PBXBuildFile; productRef = DE28F5322B7B0FED00E33058 /* SwiftProtobuf */; };
+		DE3D44AD2BD2445100BD64CD /* CryptoSwift in Frameworks */ = {isa = PBXBuildFile; productRef = DE3D44AC2BD2445100BD64CD /* CryptoSwift */; };
 		DE491CEF2B708260007C88D5 /* KeygenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE491CEE2B708260007C88D5 /* KeygenView.swift */; };
 		DE49A1672B65F6D9000F3AFB /* VoltixApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE49A1662B65F6D9000F3AFB /* VoltixApp.swift */; };
 		DE49A16D2B65F6DB000F3AFB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DE49A16C2B65F6DB000F3AFB /* Assets.xcassets */; };
@@ -537,6 +538,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DE28F5312B7B0FE900E33058 /* WalletCore in Frameworks */,
+				DE3D44AD2BD2445100BD64CD /* CryptoSwift in Frameworks */,
 				DE49A19A2B660D8D000F3AFB /* Mediator in Frameworks */,
 				DEEDAEE82B8B50A4005170E8 /* BigInt in Frameworks */,
 				DE8AD7402BC649A600339775 /* Tss.xcframework in Frameworks */,
@@ -1298,6 +1300,7 @@
 				DE28F5302B7B0FE900E33058 /* WalletCore */,
 				DE28F5322B7B0FED00E33058 /* SwiftProtobuf */,
 				DEEDAEE72B8B50A4005170E8 /* BigInt */,
+				DE3D44AC2BD2445100BD64CD /* CryptoSwift */,
 			);
 			productName = voltixApp;
 			productReference = DE49A1632B65F6D9000F3AFB /* VoltixApp.app */;
@@ -2116,6 +2119,11 @@
 		DE28F5322B7B0FED00E33058 /* SwiftProtobuf */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = SwiftProtobuf;
+		};
+		DE3D44AC2BD2445100BD64CD /* CryptoSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = DEFF59022BD23A12005DFDF9 /* XCRemoteSwiftPackageReference "CryptoSwift" */;
+			productName = CryptoSwift;
 		};
 		DE49A1992B660D8D000F3AFB /* Mediator */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/voltixApp/VoltixApp.xcodeproj/project.pbxproj
+++ b/voltixApp/VoltixApp.xcodeproj/project.pbxproj
@@ -189,6 +189,7 @@
 		DE28F5312B7B0FE900E33058 /* WalletCore in Frameworks */ = {isa = PBXBuildFile; productRef = DE28F5302B7B0FE900E33058 /* WalletCore */; };
 		DE28F5332B7B0FED00E33058 /* SwiftProtobuf in Frameworks */ = {isa = PBXBuildFile; productRef = DE28F5322B7B0FED00E33058 /* SwiftProtobuf */; };
 		DE3D44AD2BD2445100BD64CD /* CryptoSwift in Frameworks */ = {isa = PBXBuildFile; productRef = DE3D44AC2BD2445100BD64CD /* CryptoSwift */; };
+		DE3D44AF2BD2487900BD64CD /* CosmosSignature.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3D44AE2BD2487900BD64CD /* CosmosSignature.swift */; };
 		DE491CEF2B708260007C88D5 /* KeygenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE491CEE2B708260007C88D5 /* KeygenView.swift */; };
 		DE49A1672B65F6D9000F3AFB /* VoltixApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE49A1662B65F6D9000F3AFB /* VoltixApp.swift */; };
 		DE49A16D2B65F6DB000F3AFB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DE49A16C2B65F6DB000F3AFB /* Assets.xcassets */; };
@@ -461,6 +462,7 @@
 		DE1572A12B70F873009BC7C5 /* Tss.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = Tss.xcframework; sourceTree = "<group>"; };
 		DE1572AB2B7174D3009BC7C5 /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 		DE28F52B2B7B0D6500E33058 /* WalletCore */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = WalletCore; path = ../WalletCore; sourceTree = "<group>"; };
+		DE3D44AE2BD2487900BD64CD /* CosmosSignature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CosmosSignature.swift; sourceTree = "<group>"; };
 		DE491CEE2B708260007C88D5 /* KeygenView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeygenView.swift; sourceTree = "<group>"; };
 		DE49A1632B65F6D9000F3AFB /* VoltixApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = VoltixApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DE49A1662B65F6D9000F3AFB /* VoltixApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoltixApp.swift; sourceTree = "<group>"; };
@@ -705,6 +707,7 @@
 				46F8F71F2B99FDAC0099454E /* TransactionManager */,
 				469ED39E2B98F5A9008D4951 /* AccountManager */,
 				469ED3972B98E885008D4951 /* BalanceManager */,
+				DE3D44AE2BD2487900BD64CD /* CosmosSignature.swift */,
 			);
 			path = Cosmos;
 			sourceTree = "<group>";
@@ -1505,6 +1508,7 @@
 				A6F9F7ED2B9D1F5700790258 /* CoinViewModel.swift in Sources */,
 				461AD1B72BC6706500959278 /* VaultPairDetailView.swift in Sources */,
 				A6FB96B32BD0CDA900D56F68 /* NavigationEditButton.swift in Sources */,
+				DE3D44AF2BD2487900BD64CD /* CosmosSignature.swift in Sources */,
 				A6C0D5652BB3BD0F00156689 /* UTXOTransactionCell.swift in Sources */,
 				A65649F82B96701300E4B329 /* UTXOTransactionMempoolPreviousOutput.swift in Sources */,
 				DE7CE6462B886B6300ED0BFB /* VoltixVaultDocument.swift in Sources */,

--- a/voltixApp/VoltixApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/voltixApp/VoltixApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -28,6 +28,15 @@
       }
     },
     {
+      "identity" : "cryptoswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
+      "state" : {
+        "revision" : "c9c3df6ab812de32bae61fc0cd1bf6d45170ebf0",
+        "version" : "1.8.2"
+      }
+    },
+    {
       "identity" : "swifter",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/httpswift/swifter.git",

--- a/voltixApp/VoltixApp/Chains/SignedTransactionResult.swift
+++ b/voltixApp/VoltixApp/Chains/SignedTransactionResult.swift
@@ -1,0 +1,13 @@
+//
+//  SignedTransactionResult.swift
+//  VoltixApp
+//
+//  Created by Johnny Luo on 19/4/2024.
+//
+
+import Foundation
+
+struct SignedTransactionResult {
+    let rawTransaction: String
+    let transactionHash: String
+}

--- a/voltixApp/VoltixApp/Chains/Solana.swift
+++ b/voltixApp/VoltixApp/Chains/Solana.swift
@@ -80,7 +80,7 @@ enum SolanaHelper {
     static func getSignedTransaction(vaultHexPubKey: String,
                                      vaultHexChainCode: String,
                                      keysignPayload: KeysignPayload,
-                                     signatures: [String: TssKeysignResponse]) -> Result<String, Error>
+                                     signatures: [String: TssKeysignResponse]) -> Result<SignedTransactionResult, Error>
     {
         guard let pubkeyData = Data(hexString: vaultHexPubKey) else {
             return .failure(HelperError.runtimeError("public key \(vaultHexPubKey) is invalid"))
@@ -110,12 +110,18 @@ enum SolanaHelper {
                                                                                      signatures: allSignatures,
                                                                                      publicKeys: publicKeys)
                 let output = try SolanaSigningOutput(serializedData: compileWithSignature)
-                return .success(output.encoded)
+                let result = SignedTransactionResult(rawTransaction: output.encoded, 
+                                                     transactionHash: getHashFromRawTransaction(tx:output.encoded))
+                return .success(result)
             } catch {
                 return .failure(HelperError.runtimeError("fail to get signed solana transaction,error:\(error.localizedDescription)"))
             }
         case .failure(let err):
             return .failure(err)
         }
+    }
+    static func getHashFromRawTransaction(tx: String) -> String {
+        let sig =  Data(tx.prefix(64).utf8)
+        return sig.base64EncodedString()
     }
 }

--- a/voltixApp/VoltixApp/Chains/THORChainSwaps.swift
+++ b/voltixApp/VoltixApp/Chains/THORChainSwaps.swift
@@ -127,7 +127,7 @@ class THORChainSwaps {
     }
     
     func getSignedTransaction(keysignPayload: KeysignPayload,
-                              signatures: [String: TssKeysignResponse]) -> Result<String, Error>
+                              signatures: [String: TssKeysignResponse]) -> Result<SignedTransactionResult, Error>
     {
         guard let swapPayload = keysignPayload.swapPayload else {
             return .failure(HelperError.runtimeError("no swap payload"))

--- a/voltixApp/VoltixApp/Chains/UTXOChainsHelper.swift
+++ b/voltixApp/VoltixApp/Chains/UTXOChainsHelper.swift
@@ -228,7 +228,7 @@ class UTXOChainsHelper {
     
     func getSignedTransaction(
         keysignPayload: KeysignPayload,
-        signatures: [String: TssKeysignResponse]) -> Result<String, Error>
+        signatures: [String: TssKeysignResponse]) -> Result<SignedTransactionResult, Error>
     {
         let result = getBitcoinPreSigningInputData(keysignPayload: keysignPayload)
         switch result {
@@ -243,7 +243,7 @@ class UTXOChainsHelper {
     
     func getSignedTransaction(
         inputData: Data,
-        signatures: [String: TssKeysignResponse]) -> Result<String, Error>
+        signatures: [String: TssKeysignResponse]) -> Result<SignedTransactionResult, Error>
     {
         let bitcoinPubKey = getDerivedPubKey()
         guard let pubkeyData = Data(hexString: bitcoinPubKey),
@@ -269,7 +269,8 @@ class UTXOChainsHelper {
             }
             let compileWithSignatures = TransactionCompiler.compileWithSignatures(coinType: coin, txInputData: inputData, signatures: allSignatures, publicKeys: publicKeys)
             let output = try BitcoinSigningOutput(serializedData: compileWithSignatures)
-            return .success(output.encoded.hexString)
+            let result = SignedTransactionResult(rawTransaction: output.encoded.hexString, transactionHash: output.transactionID)
+            return .success(result)
         } catch {
             return .failure(HelperError.runtimeError("fail to construct raw transaction,error: \(error.localizedDescription)"))
         }

--- a/voltixApp/VoltixApp/Chains/atom.swift
+++ b/voltixApp/VoltixApp/Chains/atom.swift
@@ -180,7 +180,8 @@ class ATOMHelper {
                                                                                  publicKeys: publicKeys)
             let output = try CosmosSigningOutput(serializedData: compileWithSignature)
             let serializedData = output.serialized
-            let result = SignedTransactionResult(rawTransaction: serializedData, transactionHash: serializedData.sha256())
+            let sig = try JSONDecoder().decode(CosmosSignature.self, from: serializedData.data(using: .utf8) ?? Data())
+            let result = SignedTransactionResult(rawTransaction: serializedData, transactionHash:sig.getTransactionHash())
             return .success(result)
         } catch {
             return .failure(HelperError.runtimeError("fail to get signed transaction,error:\(error.localizedDescription)"))

--- a/voltixApp/VoltixApp/Chains/atom.swift
+++ b/voltixApp/VoltixApp/Chains/atom.swift
@@ -8,6 +8,7 @@
 import Foundation
 import WalletCore
 import Tss
+import CryptoSwift
 
 class ATOMHelper {
     let coinType: CoinType
@@ -136,7 +137,7 @@ class ATOMHelper {
     func getSignedTransaction(vaultHexPubKey: String,
                                      vaultHexChainCode: String,
                                      keysignPayload: KeysignPayload,
-                                     signatures: [String: TssKeysignResponse]) -> Result<String, Error>
+                                     signatures: [String: TssKeysignResponse]) -> Result<SignedTransactionResult, Error>
     {
         let result = getPreSignedInputData(keysignPayload: keysignPayload)
         switch result {
@@ -151,7 +152,7 @@ class ATOMHelper {
     func getSignedTransaction(vaultHexPubKey: String,
                                      vaultHexChainCode: String,
                                      inputData: Data,
-                                     signatures: [String: TssKeysignResponse]) -> Result<String, Error>
+                                     signatures: [String: TssKeysignResponse]) -> Result<SignedTransactionResult, Error>
     {
         let cosmosPublicKey = PublicKeyHelper.getDerivedPubKey(hexPubKey: vaultHexPubKey, hexChainCode: vaultHexChainCode, derivePath: self.coinType.derivationPath())
         guard let pubkeyData = Data(hexString: cosmosPublicKey),
@@ -179,8 +180,8 @@ class ATOMHelper {
                                                                                  publicKeys: publicKeys)
             let output = try CosmosSigningOutput(serializedData: compileWithSignature)
             let serializedData = output.serialized
-            print(serializedData)
-            return .success(serializedData)
+            let result = SignedTransactionResult(rawTransaction: serializedData, transactionHash: serializedData.sha256())
+            return .success(result)
         } catch {
             return .failure(HelperError.runtimeError("fail to get signed transaction,error:\(error.localizedDescription)"))
         }

--- a/voltixApp/VoltixApp/Chains/erc20.swift
+++ b/voltixApp/VoltixApp/Chains/erc20.swift
@@ -7,6 +7,7 @@ import Foundation
 import Tss
 import WalletCore
 import BigInt
+import CryptoSwift
 
 class ERC20Helper {
     let coinType: CoinType
@@ -83,7 +84,7 @@ class ERC20Helper {
     func getSignedTransaction(vaultHexPubKey: String,
                                      vaultHexChainCode: String,
                                      keysignPayload: KeysignPayload,
-                                     signatures: [String: TssKeysignResponse]) -> Result<String, Error>
+                                     signatures: [String: TssKeysignResponse]) -> Result<SignedTransactionResult, Error>
     {
         let ethPublicKey = PublicKeyHelper.getDerivedPubKey(hexPubKey: vaultHexPubKey, hexChainCode: vaultHexChainCode, derivePath: self.coinType.derivationPath())
         guard let pubkeyData = Data(hexString: ethPublicKey),
@@ -115,7 +116,9 @@ class ERC20Helper {
                                                                                      signatures: allSignatures,
                                                                                      publicKeys: publicKeys)
                 let output = try EthereumSigningOutput(serializedData: compileWithSignature)
-                return .success(output.encoded.hexString)
+                let result = SignedTransactionResult(rawTransaction: output.encoded.hexString,
+                                                     transactionHash: output.encoded.sha3(.keccak256).toHexString())
+                return .success(result)
             } catch {
                 return .failure(HelperError.runtimeError("fail to get signed ethereum transaction,error:\(error.localizedDescription)"))
             }
@@ -123,4 +126,5 @@ class ERC20Helper {
             return .failure(err)
         }
     }
+    
 }

--- a/voltixApp/VoltixApp/Chains/evm.swift
+++ b/voltixApp/VoltixApp/Chains/evm.swift
@@ -200,6 +200,7 @@ class EVMHelper {
                                                                                  signatures: allSignatures,
                                                                                  publicKeys: publicKeys)
             let output = try EthereumSigningOutput(serializedData: compileWithSignature)
+            
             return .success(output.encoded.hexString)
         } catch {
             return .failure(HelperError.runtimeError("fail to get signed ethereum transaction,error:\(error.localizedDescription)"))

--- a/voltixApp/VoltixApp/Chains/evm.swift
+++ b/voltixApp/VoltixApp/Chains/evm.swift
@@ -7,6 +7,7 @@ import BigInt
 import Foundation
 import Tss
 import WalletCore
+import CryptoSwift
 
 class EVMHelper {
     static let defaultETHTransferGasUnit:Int64 = 23000 // Increased to 23000 to support swaps and transfers with memo
@@ -157,7 +158,7 @@ class EVMHelper {
     func getSignedTransaction(vaultHexPubKey: String,
                               vaultHexChainCode: String,
                               keysignPayload: KeysignPayload,
-                              signatures: [String: TssKeysignResponse]) -> Result<String, Error>
+                              signatures: [String: TssKeysignResponse]) -> Result<SignedTransactionResult, Error>
     {
         let result = getPreSignedInputData(keysignPayload: keysignPayload)
         switch result {
@@ -171,7 +172,7 @@ class EVMHelper {
     func getSignedTransaction(vaultHexPubKey: String,
                               vaultHexChainCode: String,
                               inputData: Data,
-                              signatures: [String: TssKeysignResponse]) -> Result<String, Error>
+                              signatures: [String: TssKeysignResponse]) -> Result<SignedTransactionResult, Error>
     {
         let ethPublicKey = PublicKeyHelper.getDerivedPubKey(hexPubKey: vaultHexPubKey, hexChainCode: vaultHexChainCode, derivePath: self.coinType.derivationPath())
         guard let pubkeyData = Data(hexString: ethPublicKey),
@@ -200,10 +201,12 @@ class EVMHelper {
                                                                                  signatures: allSignatures,
                                                                                  publicKeys: publicKeys)
             let output = try EthereumSigningOutput(serializedData: compileWithSignature)
-            
-            return .success(output.encoded.hexString)
+            let result = SignedTransactionResult(rawTransaction: output.encoded.hexString,
+                                                 transactionHash: output.encoded.sha3(.keccak256).toHexString())
+            return .success(result)
         } catch {
             return .failure(HelperError.runtimeError("fail to get signed ethereum transaction,error:\(error.localizedDescription)"))
         }
     }
+    
 }

--- a/voltixApp/VoltixApp/Chains/evm.swift
+++ b/voltixApp/VoltixApp/Chains/evm.swift
@@ -202,7 +202,7 @@ class EVMHelper {
                                                                                  publicKeys: publicKeys)
             let output = try EthereumSigningOutput(serializedData: compileWithSignature)
             let result = SignedTransactionResult(rawTransaction: output.encoded.hexString,
-                                                 transactionHash: output.encoded.sha3(.keccak256).toHexString())
+                                                 transactionHash: "0x"+output.encoded.sha3(.keccak256).toHexString())
             return .success(result)
         } catch {
             return .failure(HelperError.runtimeError("fail to get signed ethereum transaction,error:\(error.localizedDescription)"))

--- a/voltixApp/VoltixApp/Chains/kujira.swift
+++ b/voltixApp/VoltixApp/Chains/kujira.swift
@@ -8,6 +8,7 @@
 import Foundation
 import WalletCore
 import Tss
+import CryptoSwift
 
 class KujiraHelper {
     let coinType: CoinType
@@ -136,7 +137,7 @@ class KujiraHelper {
     func getSignedTransaction(vaultHexPubKey: String,
                               vaultHexChainCode: String,
                               keysignPayload: KeysignPayload,
-                              signatures: [String: TssKeysignResponse]) -> Result<String, Error>
+                              signatures: [String: TssKeysignResponse]) -> Result<SignedTransactionResult, Error>
     {
         let result = getPreSignedInputData(keysignPayload: keysignPayload)
         switch result {
@@ -151,7 +152,7 @@ class KujiraHelper {
     func getSignedTransaction(vaultHexPubKey: String,
                               vaultHexChainCode: String,
                               inputData: Data,
-                              signatures: [String: TssKeysignResponse]) -> Result<String, Error>
+                              signatures: [String: TssKeysignResponse]) -> Result<SignedTransactionResult, Error>
     {
         let cosmosPublicKey = PublicKeyHelper.getDerivedPubKey(hexPubKey: vaultHexPubKey, hexChainCode: vaultHexChainCode, derivePath: self.coinType.derivationPath())
         guard let pubkeyData = Data(hexString: cosmosPublicKey),
@@ -179,8 +180,9 @@ class KujiraHelper {
                                                                                  publicKeys: publicKeys)
             let output = try CosmosSigningOutput(serializedData: compileWithSignature)
             let serializedData = output.serialized
-            print(serializedData)
-            return .success(serializedData)
+            let hash = serializedData.sha256()
+            let result = SignedTransactionResult(rawTransaction: serializedData, transactionHash:hash)
+            return .success(result)
         } catch {
             return .failure(HelperError.runtimeError("fail to get signed transaction,error:\(error.localizedDescription)"))
         }

--- a/voltixApp/VoltixApp/Chains/kujira.swift
+++ b/voltixApp/VoltixApp/Chains/kujira.swift
@@ -180,8 +180,8 @@ class KujiraHelper {
                                                                                  publicKeys: publicKeys)
             let output = try CosmosSigningOutput(serializedData: compileWithSignature)
             let serializedData = output.serialized
-            let hash = serializedData.sha256()
-            let result = SignedTransactionResult(rawTransaction: serializedData, transactionHash:hash)
+            let sig = try JSONDecoder().decode(CosmosSignature.self, from: serializedData.data(using: .utf8) ?? Data())
+            let result = SignedTransactionResult(rawTransaction: serializedData, transactionHash:sig.getTransactionHash())
             return .success(result)
         } catch {
             return .failure(HelperError.runtimeError("fail to get signed transaction,error:\(error.localizedDescription)"))

--- a/voltixApp/VoltixApp/Chains/maya.swift
+++ b/voltixApp/VoltixApp/Chains/maya.swift
@@ -185,8 +185,8 @@ enum MayaChainHelper {
                                                                                  publicKeys: publicKeys)
             let output = try CosmosSigningOutput(serializedData: compileWithSignature)
             let serializedData = output.serialized
-            let hash = serializedData.sha256()
-            let result = SignedTransactionResult(rawTransaction: serializedData, transactionHash:hash)
+            let sig = try JSONDecoder().decode(CosmosSignature.self, from: serializedData.data(using: .utf8) ?? Data())
+            let result = SignedTransactionResult(rawTransaction: serializedData, transactionHash:sig.getTransactionHash())
             return .success(result)
         } catch {
             return .failure(HelperError.runtimeError("fail to get signed ethereum transaction,error:\(error.localizedDescription)"))

--- a/voltixApp/VoltixApp/Chains/maya.swift
+++ b/voltixApp/VoltixApp/Chains/maya.swift
@@ -8,6 +8,7 @@
 import Foundation
 import Tss
 import WalletCore
+import CryptoSwift
 
 enum MayaChainHelper {
     static let MayaChainGas: UInt64 = 2000000
@@ -141,7 +142,7 @@ enum MayaChainHelper {
     static func getSignedTransaction(vaultHexPubKey: String,
                                      vaultHexChainCode: String,
                                      keysignPayload: KeysignPayload,
-                                     signatures: [String: TssKeysignResponse]) -> Result<String, Error>
+                                     signatures: [String: TssKeysignResponse]) -> Result<SignedTransactionResult, Error>
     {
         let result = getPreSignedInputData(keysignPayload: keysignPayload)
         switch result {
@@ -156,7 +157,7 @@ enum MayaChainHelper {
     static func getSignedTransaction(vaultHexPubKey: String,
                                      vaultHexChainCode: String,
                                      inputData: Data,
-                                     signatures: [String: TssKeysignResponse]) -> Result<String, Error>
+                                     signatures: [String: TssKeysignResponse]) -> Result<SignedTransactionResult, Error>
     {
         let thorPublicKey = PublicKeyHelper.getDerivedPubKey(hexPubKey: vaultHexPubKey, hexChainCode: vaultHexChainCode, derivePath: CoinType.thorchain.derivationPath())
         guard let pubkeyData = Data(hexString: thorPublicKey),
@@ -184,8 +185,9 @@ enum MayaChainHelper {
                                                                                  publicKeys: publicKeys)
             let output = try CosmosSigningOutput(serializedData: compileWithSignature)
             let serializedData = output.serialized
-            print(serializedData)
-            return .success(serializedData)
+            let hash = serializedData.sha256()
+            let result = SignedTransactionResult(rawTransaction: serializedData, transactionHash:hash)
+            return .success(result)
         } catch {
             return .failure(HelperError.runtimeError("fail to get signed ethereum transaction,error:\(error.localizedDescription)"))
         }

--- a/voltixApp/VoltixApp/Chains/thorchain.swift
+++ b/voltixApp/VoltixApp/Chains/thorchain.swift
@@ -141,7 +141,7 @@ enum THORChainHelper {
     static func getSignedTransaction(vaultHexPubKey: String,
                                      vaultHexChainCode: String,
                                      keysignPayload: KeysignPayload,
-                                     signatures: [String: TssKeysignResponse]) -> Result<String, Error>
+                                     signatures: [String: TssKeysignResponse]) -> Result<SignedTransactionResult, Error>
     {
         let result = getPreSignedInputData(keysignPayload: keysignPayload)
         switch result {
@@ -156,7 +156,7 @@ enum THORChainHelper {
     static func getSignedTransaction(vaultHexPubKey: String,
                                      vaultHexChainCode: String,
                                      inputData: Data,
-                                     signatures: [String: TssKeysignResponse]) -> Result<String, Error>
+                                     signatures: [String: TssKeysignResponse]) -> Result<SignedTransactionResult, Error>
     {
         let thorPublicKey = PublicKeyHelper.getDerivedPubKey(hexPubKey: vaultHexPubKey, hexChainCode: vaultHexChainCode, derivePath: CoinType.thorchain.derivationPath())
         guard let pubkeyData = Data(hexString: thorPublicKey),
@@ -184,10 +184,14 @@ enum THORChainHelper {
                                                                                  publicKeys: publicKeys)
             let output = try CosmosSigningOutput(serializedData: compileWithSignature)
             let serializedData = output.serialized
-            print(serializedData)
-            return .success(serializedData)
+            let hash = serializedData.sha256()
+            let result = SignedTransactionResult(rawTransaction: serializedData, transactionHash:hash)
+            return .success(result)
         } catch {
             return .failure(HelperError.runtimeError("fail to get signed ethereum transaction,error:\(error.localizedDescription)"))
         }
     }
+    
+    
+    
 }

--- a/voltixApp/VoltixApp/Chains/thorchain.swift
+++ b/voltixApp/VoltixApp/Chains/thorchain.swift
@@ -184,8 +184,8 @@ enum THORChainHelper {
                                                                                  publicKeys: publicKeys)
             let output = try CosmosSigningOutput(serializedData: compileWithSignature)
             let serializedData = output.serialized
-            let hash = serializedData.sha256()
-            let result = SignedTransactionResult(rawTransaction: serializedData, transactionHash:hash)
+            let sig = try JSONDecoder().decode(CosmosSignature.self, from: serializedData.data(using: .utf8) ?? Data())
+            let result = SignedTransactionResult(rawTransaction: serializedData, transactionHash:sig.getTransactionHash())
             return .success(result)
         } catch {
             return .failure(HelperError.runtimeError("fail to get signed ethereum transaction,error:\(error.localizedDescription)"))

--- a/voltixApp/VoltixApp/Model/Cosmos/CosmosSignature.swift
+++ b/voltixApp/VoltixApp/Model/Cosmos/CosmosSignature.swift
@@ -1,0 +1,17 @@
+//
+//  CosmosSignature.swift
+//  VoltixApp
+//
+//  Created by Johnny Luo on 19/4/2024.
+//
+
+import Foundation
+
+struct CosmosSignature : Codable{
+    let mode: String
+    let tx_bytes: String
+    func getTransactionHash() -> String {
+        return Data(base64Encoded: tx_bytes)?.sha256().toHexString() ?? ""
+    }
+}
+

--- a/voltixApp/VoltixApp/Services/RpcEvmService.swift
+++ b/voltixApp/VoltixApp/Services/RpcEvmService.swift
@@ -172,7 +172,7 @@ class RpcEvmService {
         } catch {
             print(payload)
             print(error.localizedDescription)
-            throw RpcEvmServiceError.rpcError(code: 500, message: error.localizedDescription)
+            throw error
         }
 
     }

--- a/voltixApp/VoltixApp/Services/Thorchain/ThorchainBroadcastTransactionService.swift
+++ b/voltixApp/VoltixApp/Services/Thorchain/ThorchainBroadcastTransactionService.swift
@@ -9,7 +9,7 @@ import Foundation
 
 extension ThorchainService {
     
-    func broadcastTransaction(jsonString: String) async -> Result<String,Error> {
+func broadcastTransaction(jsonString: String) async -> Result<String,Error> {
         let url = URL(string: Endpoint.broadcastTransactionThorchainNineRealms)!
         
         guard let jsonData = jsonString.data(using: .utf8) else {

--- a/voltixApp/VoltixApp/View Models/KeysignViewModel.swift
+++ b/voltixApp/VoltixApp/View Models/KeysignViewModel.swift
@@ -332,7 +332,7 @@ class KeysignViewModel: ObservableObject {
         case HelperError.runtimeError(let errDetail):
             errMessage = "Failed to broadcast transaction,\(errDetail)"
         case RpcEvmServiceError.rpcError(let code, let message):
-            if message == "already known"{
+            if message == "already known" || message == "replacement transaction underpriced" {
                 print("the transaction already broadcast,code:\(code)")
                 self.txid = ""
                 return

--- a/voltixApp/VoltixApp/View Models/KeysignViewModel.swift
+++ b/voltixApp/VoltixApp/View Models/KeysignViewModel.swift
@@ -258,7 +258,6 @@ class KeysignViewModel: ObservableObject {
         let result = getSignedTransaction(keysignPayload: keysignPayload)
         switch result {
         case .success(let tx):
-            print("tx:\(tx.rawTransaction),hash:\(tx.transactionHash)")
             do {
                 switch keysignPayload.coin.chain {
                 case .thorChain:

--- a/voltixApp/VoltixApp/View Models/KeysignViewModel.swift
+++ b/voltixApp/VoltixApp/View Models/KeysignViewModel.swift
@@ -181,7 +181,7 @@ class KeysignViewModel: ObservableObject {
         return try await t.value
     }
     
-    func getSignedTransaction(keysignPayload: KeysignPayload) -> Result<String, Error> {
+    func getSignedTransaction(keysignPayload: KeysignPayload) -> Result<SignedTransactionResult, Error> {
         if keysignPayload.swapPayload != nil {
             let swaps = THORChainSwaps(vaultHexPublicKey: vault.pubKeyECDSA, vaultHexChainCode: vault.hexChainCode)
             let result = swaps.getSignedTransaction(keysignPayload: keysignPayload, signatures: signatures)
@@ -258,83 +258,85 @@ class KeysignViewModel: ObservableObject {
         
         let result = getSignedTransaction(keysignPayload: keysignPayload)
         
-        do {
-            switch result {
-            case .success(let tx):
-                
+        
+        switch result {
+        case .success(let tx):
+            do {
                 switch keysignPayload.coin.chain {
                 case .thorChain:
-                    let broadcastResult = await ThorchainService.shared.broadcastTransaction(jsonString: tx)
+                    let broadcastResult = await ThorchainService.shared.broadcastTransaction(jsonString: tx.rawTransaction)
                     switch broadcastResult {
                     case .success(let txHash):
                         self.txid = txHash
                         print("Transaction successful, hash: \(txHash)")
                     case .failure(let error):
-                        self.handleBroadcastError(err: error)
+                        throw error
                     }
                 case .mayaChain:
-                    let broadcastResult = await MayachainService.shared.broadcastTransaction(jsonString: tx)
+                    let broadcastResult = await MayachainService.shared.broadcastTransaction(jsonString: tx.rawTransaction)
                     switch broadcastResult {
                     case .success(let txHash):
                         self.txid = txHash
                         print("Transaction successful, hash: \(txHash)")
                     case .failure(let error):
-                        self.handleBroadcastError(err: error)
+                        throw error
                     }
                 case .ethereum:
-                    self.txid = try await etherScanService.broadcastTransaction(hex: tx)
+                    self.txid = try await etherScanService.broadcastTransaction(hex: tx.rawTransaction)
                     
                 case .avalanche:
-                    self.txid = try await avaxScanService.broadcastTransaction(hex: tx)
+                    self.txid = try await avaxScanService.broadcastTransaction(hex: tx.rawTransaction)
                     
                 case .bscChain:
-                    self.txid = try await bscService.broadcastTransaction(hex: tx)
+                    self.txid = try await bscService.broadcastTransaction(hex: tx.rawTransaction)
                     
                 case .bitcoin, .bitcoinCash, .litecoin, .dogecoin, .dash:
                     let chainName = keysignPayload.coin.chain.name.lowercased()
-                    UTXOTransactionsService.broadcastTransaction(chain: chainName, signedTransaction: tx) { result in
+                    UTXOTransactionsService.broadcastTransaction(chain: chainName, signedTransaction: tx.rawTransaction) { result in
                         switch result {
                         case .success(let transactionHash):
                             self.txid = transactionHash
                         case .failure(let error):
-                            self.handleBroadcastError(err: error)
+                            self.handleBroadcastError(err: error,tx:tx)
                         }
                     }
                 case .gaiaChain:
-                    let broadcastResult = await GaiaService.shared.broadcastTransaction(jsonString: tx)
+                    let broadcastResult = await GaiaService.shared.broadcastTransaction(jsonString: tx.rawTransaction)
                     switch broadcastResult {
                     case .success(let hash):
                         self.txid = hash
                     case .failure(let err):
-                        self.handleBroadcastError(err: err)
+                        throw err
                     }
                 case .kujira:
-                    let broadcastResult = await KujiraService.shared.broadcastTransaction(jsonString: tx)
+                    let broadcastResult = await KujiraService.shared.broadcastTransaction(jsonString: tx.rawTransaction)
                     switch broadcastResult {
                     case .success(let hash):
                         self.txid = hash
                     case .failure(let err):
-                        self.handleBroadcastError(err: err)
+                        throw err
                     }
                 case .solana:
-                    self.txid = await SolanaService.shared.sendSolanaTransaction(encodedTransaction: tx) ?? ""
+                    self.txid = await SolanaService.shared.sendSolanaTransaction(encodedTransaction: tx.rawTransaction) ?? ""
                 }
-            case .failure(let error):
-                handleHelperError(err: error)
+            } catch {
+                handleBroadcastError(err: error,tx: tx)
             }
-        } catch {
-            handleBroadcastError(err: error)
+        case .failure(let error):
+            handleHelperError(err: error)
         }
+        
     }
-    func handleBroadcastError(err: Error){
+    func handleBroadcastError(err: Error,tx: SignedTransactionResult){
         var errMessage: String = ""
         switch err{
         case HelperError.runtimeError(let errDetail):
             errMessage = "Failed to broadcast transaction,\(errDetail)"
         case RpcEvmServiceError.rpcError(let code, let message):
+            print("code:\(code), message:\(message)")
             if message == "already known" || message == "replacement transaction underpriced" {
                 print("the transaction already broadcast,code:\(code)")
-                self.txid = ""
+                self.txid = tx.transactionHash
                 return
             }
         default:

--- a/voltixApp/VoltixApp/View Models/KeysignViewModel.swift
+++ b/voltixApp/VoltixApp/View Models/KeysignViewModel.swift
@@ -255,12 +255,10 @@ class KeysignViewModel: ObservableObject {
     
     func broadcastTransaction() async {
         guard let keysignPayload else { return }
-        
         let result = getSignedTransaction(keysignPayload: keysignPayload)
-        
-        
         switch result {
         case .success(let tx):
+            print("tx:\(tx.rawTransaction),hash:\(tx.transactionHash)")
             do {
                 switch keysignPayload.coin.chain {
                 case .thorChain:

--- a/voltixApp/VoltixApp/View Models/KeysignViewModel.swift
+++ b/voltixApp/VoltixApp/View Models/KeysignViewModel.swift
@@ -327,10 +327,16 @@ class KeysignViewModel: ObservableObject {
         }
     }
     func handleBroadcastError(err: Error){
-        var errMessage: String
+        var errMessage: String = ""
         switch err{
         case HelperError.runtimeError(let errDetail):
             errMessage = "Failed to broadcast transaction,\(errDetail)"
+        case RpcEvmServiceError.rpcError(let code, let message):
+            if message == "already known"{
+                print("the transaction already broadcast,code:\(code)")
+                self.txid = ""
+                return
+            }
         default:
             errMessage = "Failed to broadcast transaction,error:\(err.localizedDescription)"
         }

--- a/voltixApp/VoltixApp/Views/Send/SendCryptoDoneView.swift
+++ b/voltixApp/VoltixApp/Views/Send/SendCryptoDoneView.swift
@@ -99,12 +99,20 @@ struct SendCryptoDoneView: View {
     }
     
     private func copyHash() {
+        // legitimate hash should not have space in it
+        if hash.contains(" ") {
+            return
+        }
         showAlert = true
         let pasteboard = UIPasteboard.general
         pasteboard.string = hash
     }
     
     private func shareLink() {
+        // legitimate hash should not have space in it
+        if hash.contains(" ") {
+            return
+        }
         if !explorerLink.isEmpty, let u = URL(string:explorerLink) {
             openURL(u)
         }

--- a/voltixApp/VoltixApp/Views/Send/SendCryptoDoneView.swift
+++ b/voltixApp/VoltixApp/Views/Send/SendCryptoDoneView.swift
@@ -99,20 +99,12 @@ struct SendCryptoDoneView: View {
     }
     
     private func copyHash() {
-        // legitimate hash should not have space in it
-        if hash.contains(" ") {
-            return
-        }
         showAlert = true
         let pasteboard = UIPasteboard.general
         pasteboard.string = hash
     }
     
     private func shareLink() {
-        // legitimate hash should not have space in it
-        if hash.contains(" ") {
-            return
-        }
         if !explorerLink.isEmpty, let u = URL(string:explorerLink) {
             openURL(u)
         }


### PR DESCRIPTION
When using TSS to sign a transaction , two devices are doing the keysign interactively, when keysign finished , two devices both get the signature , and construct the transaction to broadcast. of course one will succeed and the other one will get an error , due to blockchain's double spend protection. 

Usually the slower device will get an error like `"code: -32000, message: already known"` , or on some chains have very short block time , it will get another `"code: -32000, message: replacement transaction underpriced"`

This PR will mark these two types of errors as success, (mostly EVM chain).  But in order to make the UI/UX user friendly , we also need to figure out the transaction hash based on the raw transaction before broadcast 
why? because when broadcast return an error , transaction hash is not part of the response , the error party need to know the transaction hash when mark it as a successful 